### PR TITLE
fix: preserve Hono app types in health handler

### DIFF
--- a/docs/integrations/hono.md
+++ b/docs/integrations/hono.md
@@ -34,6 +34,49 @@ type AppEnv = MedicusVariables;
 
 The health handler does `c.set('medicus', medicus)` so other middleware/routes can read the same instance from request context.
 
+If your Hono app defines custom `Bindings` or `Variables`, pass the same app type to `createHonoHealthCheckHandler`.
+TypeScript cannot infer that type from the surrounding `app.get(...)` call, so the explicit generic is required for typed checker context.
+
+```ts
+import { Hono } from 'hono';
+import { HealthStatus } from 'medicus';
+import { createHonoHealthCheckHandler } from 'medicus/hono';
+
+type App = {
+  Bindings: {
+    RELEASE: string;
+  };
+  Variables: {
+    db: {
+      healthCheck(): Promise<void>;
+    };
+    requestId: string;
+  };
+};
+
+const app = new Hono<App>();
+
+app.get(
+  '/health',
+  createHonoHealthCheckHandler<App>({
+    debug: true,
+    checkers: {
+      async database(ctx) {
+        await ctx.get('db').healthCheck();
+
+        return {
+          status: HealthStatus.HEALTHY,
+          debug: {
+            release: ctx.env.RELEASE,
+            requestId: ctx.get('requestId')
+          }
+        };
+      }
+    }
+  })
+);
+```
+
 ## Edge Runtime Note
 
 On edge runtimes (for example Cloudflare Workers), application instances are typically spun up per request.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medicus",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A flexible and agnostic health check library for Node.js.",
   "bugs": {
     "url": "https://github.com/arthurfiorette/medicus/issues"

--- a/src/integrations/hono.ts
+++ b/src/integrations/hono.ts
@@ -23,8 +23,8 @@ export type MedicusVariables<
   E extends Env = Env,
   P extends string = string,
   I extends Input = Input
-> = {
-  Variables: {
+> = E & {
+  Variables: E['Variables'] & {
     medicus: Medicus<Context<MedicusVariables<E, P, I>, P, I>>;
   };
 };

--- a/src/integrations/hono.ts
+++ b/src/integrations/hono.ts
@@ -68,9 +68,28 @@ export type HonoHealthCheckHandler<
  * app.get(
  *   '/health',
  *   createHonoHealthCheckHandler({
- *   checkers: {
- *     database: () => HealthStatus.HEALTHY
- *   }
+ *     checkers: {
+ *       database: () => HealthStatus.HEALTHY
+ *     }
+ *   })
+ * );
+ *
+ * type App = {
+ *   Bindings: { RELEASE: string };
+ *   Variables: { db: { healthCheck(): Promise<void> } };
+ * };
+ *
+ * const typedApp = new Hono<App>();
+ *
+ * typedApp.get(
+ *   '/health',
+ *   createHonoHealthCheckHandler<App>({
+ *     checkers: {
+ *       async database(ctx) {
+ *         await ctx.get('db').healthCheck();
+ *         return HealthStatus.HEALTHY;
+ *       }
+ *     }
  *   })
  * );
  * ```

--- a/test/integrations/hono.test.ts
+++ b/test/integrations/hono.test.ts
@@ -148,4 +148,62 @@ describe('Hono Integration', () => {
     assert.equal(response.status, 200);
     assert.equal(hasMedicusOnContext, true);
   });
+
+  it('preserves custom Hono app bindings and variables in checkers', async () => {
+    type App = {
+      Bindings: {
+        RELEASE: string;
+      };
+      Variables: {
+        db: {
+          healthCheck(): Promise<void>;
+        };
+        requestId: string;
+      };
+    };
+
+    const app = new Hono<App>();
+    let checkedDb = false;
+
+    app.use('*', async (context, next) => {
+      context.set('db', {
+        async healthCheck() {
+          checkedDb = true;
+        }
+      });
+      context.set('requestId', 'req-1');
+
+      await next();
+    });
+
+    app.get(
+      '/health',
+      createHonoHealthCheckHandler<App>({
+        debug: true,
+        checkers: {
+          async typedContext(context) {
+            await context.get('db').healthCheck();
+
+            return {
+              status: HealthStatus.HEALTHY,
+              debug: {
+                hasMedicus: context.get('medicus') instanceof Medicus,
+                release: context.env.RELEASE,
+                requestId: context.get('requestId')
+              }
+            };
+          }
+        }
+      })
+    );
+
+    const response = await app.request('/health', undefined, { RELEASE: 'test' });
+    const body: any = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(checkedDb, true);
+    assert.equal(body.services.typedContext.debug.hasMedicus, true);
+    assert.equal(body.services.typedContext.debug.release, 'test');
+    assert.equal(body.services.typedContext.debug.requestId, 'req-1');
+  });
 });


### PR DESCRIPTION
## Summary
- Preserve caller Hono `Bindings` and `Variables` when injecting the Medicus context variable.
- Add Hono coverage proving checker context can access custom variables, bindings, and `medicus` without casts.
- Bump package patch version to `1.4.1` and document typed Hono handler usage.

## Verification
- `pnpm test`
- `pnpm lint` (Biome schema-version info only)