### PR TITLE
Add Elysia, Express, and H3/Nitro integrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ dist
 node_modules
 coverage
 docs/.vitepress/cache
+docs/.vitepress/temp
 
 *.tsbuildinfo
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 <br />
 
-Medicus is a comprehensive, agnostic health check library for Node.js. It provides an easy way to monitor the health of various services and integrates seamlessly with Fastify.
+Medicus is a comprehensive, framework-agnostic health check library for Node.js. It provides ready-made integrations for Fastify, Express, Elysia, Hono, H3, Nitro and plain HTTP servers.
 
 <br />
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -233,6 +233,18 @@ export default defineConfig({
             link: 'fastify.md'
           },
           {
+            text: 'Express',
+            link: 'express.md'
+          },
+          {
+            text: 'Elysia',
+            link: 'elysia.md'
+          },
+          {
+            text: 'H3 / Nitro',
+            link: 'h3.md'
+          },
+          {
             text: 'Hono',
             link: 'hono.md'
           },

--- a/docs/background-checks.md
+++ b/docs/background-checks.md
@@ -1,6 +1,6 @@
 ---
 title: Scheduled Background Health Checks
-description: Run Node.js health checks on an interval instead of per request — background scheduling, cached results, eager startup checks and check event listeners.
+description: Run Node.js health checks on an interval instead of per request, with background scheduling, cached results, eager startup checks and check event listeners.
 ---
 
 # Background Checks

--- a/docs/guides/key-value-stores.md
+++ b/docs/guides/key-value-stores.md
@@ -5,11 +5,11 @@ description: 'Redis health check patterns for Node.js: PING checkers, read-after
 
 # Key-Value Stores
 
-Redis, Valkey, Memcached, DynamoDB, Cloudflare KV — the health check pattern is the same for all of them: perform the cheapest possible operation and let the promise settle. If it resolves, the service is healthy; if it rejects, Medicus marks it unhealthy and forwards the error to the [error logger](../logger.md).
+Redis, Valkey, Memcached, DynamoDB and Cloudflare KV use the same health check pattern: perform the cheapest possible operation and let the promise settle. If it resolves, the service is healthy; if it rejects, Medicus marks it unhealthy and forwards the error to the [error logger](../logger.md).
 
 ## Basic checker
 
-Clients with a dedicated ping command make the Redis health check — and its Valkey and Memcached equivalents — a one-liner:
+Clients with a dedicated ping command make the Redis health check, including its Valkey and Memcached equivalents, a one-liner:
 
 ```ts
 medicus.addChecker({

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ layout: home
 
 title: Medicus, the Node.js Health Check Library
 titleTemplate: false
-description: Framework-agnostic health check library for Node.js and TypeScript. Ready-made health check endpoints for Fastify, Hono, plain HTTP and background workers.
+description: Framework-agnostic health check library for Node.js and TypeScript. Ready-made endpoints for Fastify, Express, Elysia, Hono, H3, Nitro and plain HTTP.
 
 hero:
   name: 'Medicus'

--- a/docs/integrations/elysia.md
+++ b/docs/integrations/elysia.md
@@ -1,0 +1,47 @@
+---
+title: Elysia Health Check Handler
+description: Add a Medicus health check handler to any user-defined Elysia route with typed request context and explicit lifecycle ownership.
+---
+
+# Elysia <Badge type="warning" text="Third-Party" />
+
+Attach the handler to your health route. Medicus does not register the path automatically:
+
+```ts
+import { Elysia } from 'elysia';
+import { HealthStatus } from 'medicus';
+import { createElysiaHealthCheckHandler } from 'medicus/elysia';
+
+const app = new Elysia()
+  .get(
+    '/health',
+    createElysiaHealthCheckHandler({
+      checkers: {
+        database(context) {
+          console.log(context.request.url);
+          return HealthStatus.HEALTHY;
+        }
+      }
+    })
+  )
+  .listen(3000);
+```
+
+Checkers receive the current Elysia request context. `/health` is only the conventional example; the application owns the route path.
+
+## Query Parameters
+
+- `?debug=true` - Include checker details.
+- `?last=true` - Return the last cached result, or run a check if none exists.
+- `?simulate=healthy|degraded|unhealthy` - Override the returned status for testing.
+
+Healthy and degraded results return `200`; unhealthy results return `503`. Responses default to `Content-Type: application/json; charset=utf-8` and `Cache-Control: no-cache, no-store, must-revalidate`.
+
+## Options
+
+`createElysiaHealthCheckHandler` accepts all `Medicus` constructor options except `context`, plus:
+
+- `debug?: boolean` - Include checker details by default.
+- `headers?: Record<string, string>` - Add or override response headers.
+
+See the Elysia documentation for [routes](https://elysiajs.com/essential/route.html) and [testing with `app.handle`](https://elysiajs.com/patterns/unit-test.html).

--- a/docs/integrations/express.md
+++ b/docs/integrations/express.md
@@ -1,0 +1,63 @@
+---
+title: Express Health Check Handler
+description: Add a typed health check route to Express 4.21+ or 5.2+ with request context, HTTP status mapping, debug output and cached checks.
+---
+
+# Express <Badge type="warning" text="Third-Party" />
+
+Attach `createExpressHealthCheckHandler` to a GET route. Checkers receive the current Express `Request` as their context:
+
+```ts
+import express from 'express';
+import { HealthStatus } from 'medicus';
+import { createExpressHealthCheckHandler } from 'medicus/express';
+
+const app = express();
+app.get(
+  '/health',
+  createExpressHealthCheckHandler({
+    checkers: {
+      database(req) {
+        console.log(`Health check from ${req.ip}`);
+        return HealthStatus.HEALTHY;
+      }
+    }
+  })
+);
+```
+
+The handler exposes its `Medicus` instance for late checker registration and shutdown:
+
+```ts
+import express from 'express';
+import { createExpressHealthCheckHandler } from 'medicus/express';
+
+const app = express();
+const health = createExpressHealthCheckHandler();
+app.get('/health', health);
+const server = app.listen(3000);
+
+process.on('SIGTERM', () => {
+  health.medicus.stopBackgroundCheck();
+  server.close();
+});
+```
+
+Express does not own an application shutdown lifecycle, so stop background checks in the same shutdown handler that closes your HTTP server and other resources.
+
+## Query Parameters
+
+- `?debug=true` - Include checker details.
+- `?last=true` - Return the last cached result, or run a check if none exists.
+- `?simulate=healthy|degraded|unhealthy` - Override the returned status for testing.
+
+Healthy and degraded results return `200`; unhealthy results return `503`. Responses default to `Content-Type: application/json; charset=utf-8` and `Cache-Control: no-cache, no-store, must-revalidate`.
+
+## Options
+
+`createExpressHealthCheckHandler` accepts all `Medicus` constructor options except `context`, plus:
+
+- `debug?: boolean` - Include checker details by default.
+- `headers?: Record<string, string>` - Add or override response headers.
+
+See the [Express middleware guide](https://expressjs.com/en/guide/using-middleware.html) and [health check and graceful shutdown guide](https://expressjs.com/en/advanced/healthcheck-graceful-shutdown.html).

--- a/docs/integrations/fastify.md
+++ b/docs/integrations/fastify.md
@@ -40,6 +40,9 @@ import { fastifyMedicusPlugin } from 'medicus/fastify';
 const app = fastify();
 
 app.register(fastifyMedicusPlugin, {
+  headers: {
+    'x-health-check': 'medicus'
+  },
   route: {
     url: '/-/health',
     logLevel: 'silent'
@@ -48,5 +51,9 @@ app.register(fastifyMedicusPlugin, {
 ```
 
 Setting `route: false` disables the route entirely while keeping checkers and [background checks](../background-checks.md) running. This is useful for workers that use Fastify as a plugin container without ever calling `listen()`, as shown in the [background workers guide](../guides/background-workers.md).
+
+## Response Headers
+
+Responses default to `Content-Type: application/json; charset=utf-8` and `Cache-Control: no-cache, no-store, must-revalidate`. Use the `headers` option to add or override response headers.
 
 For more details about Fastify, visit the [Fastify documentation](https://www.fastify.io/).

--- a/docs/integrations/h3.md
+++ b/docs/integrations/h3.md
@@ -1,0 +1,75 @@
+---
+title: H3 and Nitro Health Check Handler
+description: Use one Web-standard health check event handler with H3 applications and Nitro filesystem routes across current framework generations.
+---
+
+# H3 / Nitro <Badge type="warning" text="Third-Party" />
+
+`createH3HealthCheckHandler` creates an H3 event handler. Checkers receive the current `H3Event`, and the handler exposes its underlying `Medicus` instance.
+
+## Nitro Route
+
+Export the handler directly from a Nitro filesystem route:
+
+```ts
+// server/routes/health.get.ts
+import { HealthStatus } from 'medicus';
+import { createH3HealthCheckHandler } from 'medicus/h3';
+
+export default createH3HealthCheckHandler({
+  checkers: {
+    database(event) {
+      console.log(event.path);
+      return HealthStatus.HEALTHY;
+    }
+  }
+});
+```
+
+No separate Nitro adapter is needed because Nitro route handlers use H3 events directly.
+
+## H3 Application
+
+With stable H3 1.x:
+
+```ts
+import { createApp } from 'h3';
+import { createH3HealthCheckHandler } from 'medicus/h3';
+
+const app = createApp();
+app.use('/health', createH3HealthCheckHandler());
+```
+
+H3 2 and Nitro 3 use `defineHandler` and Web-standard request/response primitives. The Medicus handler is a plain event function returning a Web `Response`, so it can be registered directly without wrapping it in either `defineEventHandler` or `defineHandler`.
+
+## Query Parameters
+
+- `?debug=true` - Include checker details.
+- `?last=true` - Return the last cached result, or run a check if none exists.
+- `?simulate=healthy|degraded|unhealthy` - Override the returned status for testing.
+
+Healthy and degraded results return `200`; unhealthy results return `503`. Responses default to `Content-Type: application/json; charset=utf-8` and `Cache-Control: no-cache, no-store, must-revalidate`.
+
+## Lifecycle
+
+The handler exposes `handler.medicus`. Stop background checks from your Nitro or H3 application shutdown hook:
+
+```ts
+import { createH3HealthCheckHandler } from 'medicus/h3';
+
+const health = createH3HealthCheckHandler();
+
+// During application shutdown
+health.medicus.stopBackgroundCheck();
+```
+
+Leave `backgroundCheckInterval` unset on serverless or edge deployments.
+
+## Options
+
+`createH3HealthCheckHandler` accepts all `Medicus` constructor options except `context`, plus:
+
+- `debug?: boolean` - Include checker details by default.
+- `headers?: Record<string, string>` - Add or override response headers.
+
+See the current [H3 event handler documentation](https://h3.dev/guide/basics/handler), [H3 1.x documentation](https://v1.h3.dev/guide/event-handler), and [Nitro routing documentation](https://nitro.build/guide/routing).

--- a/docs/integrations/hono.md
+++ b/docs/integrations/hono.md
@@ -93,6 +93,8 @@ Because of that lifecycle, background checks are not suitable and should remain 
 - `?last` - Return cached result
 - `?simulate=unhealthy|degraded|healthy` - Simulate status
 
+Responses default to `Content-Type: application/json; charset=utf-8` and `Cache-Control: no-cache, no-store, must-revalidate`.
+
 ## Options
 
 ```ts

--- a/docs/integrations/http.md
+++ b/docs/integrations/http.md
@@ -44,6 +44,8 @@ const server = createServer((req, res) => {
 ```ts
 interface HttpHealthCheckOptions {
   debug?: boolean; // Include debug info by default
-  headers?: Record<string, string>; // Custom headers (includes cache prevention by default)
+  headers?: Record<string, string>; // Add or override response headers
 }
 ```
+
+Responses default to `Content-Type: application/json; charset=utf-8` and `Cache-Control: no-cache, no-store, must-revalidate`.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,6 +1,6 @@
 ---
-title: Health Check Integrations for Fastify, Hono, Node.js & More
-description: 'Native health check integrations for Node.js frameworks: Fastify plugin, Hono route, plain HTTP endpoint, TanStack Start, Avvio and Pino.'
+title: Health Check Integrations for Node.js Frameworks
+description: 'Health check integrations for Fastify, Express, Elysia, Hono, H3, Nitro, TanStack Start, Node HTTP, Avvio and Pino.'
 ---
 
 # Integrations
@@ -19,6 +19,10 @@ Plugins are used within `Medicus`'s `plugins` configuration option to enhance it
 These integrations allow you to seamlessly connect `Medicus` with external libraries and frameworks:
 
 - **[Avvio](./avvio.md):** Hooks `Medicus` into the `Avvio` lifecycle to initiate health checks after the server is ready.
+- **[Elysia](./elysia.md):** Provides a route handler that can be mounted at any application-defined path.
+- **[Express](./express.md):** Provides an Express 4 and 5 route handler with request context.
 - **[Fastify](./fastify.md):** Attaches `Medicus` to `Fastify` instance lifecycle hooks for streamlined integration.
+- **[H3 / Nitro](./h3.md):** Exposes one event handler for H3 applications and Nitro filesystem routes.
 - **[Hono](./hono.md):** Exposes a ready-to-use health check route handler for Hono applications.
+- **[HTTP](./http.md):** Adds a health endpoint to a plain `node:http` server.
 - **[TanStack Start](./tanstack-start.md):** Provides a health check handler for TanStack Start server functions.

--- a/docs/integrations/tanstack-start.md
+++ b/docs/integrations/tanstack-start.md
@@ -23,7 +23,7 @@ export const getHealth = createServerFn({ method: 'GET' }).handler(
 );
 ```
 
-The integration has no dependency on `@tanstack/react-start` or `@tanstack/solid-start` — the handler is structurally compatible with `createServerFn().handler()` in both.
+The integration has no dependency on `@tanstack/react-start` or `@tanstack/solid-start`; the handler is structurally compatible with `createServerFn().handler()` in both.
 
 ## Input Flags
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "medicus",
   "version": "1.5.0",
-  "description": "Flexible, framework-agnostic health check library for Node.js and TypeScript. Liveness and readiness checks with Fastify, Hono, Avvio and plain HTTP integrations.",
+  "description": "Flexible, framework-agnostic health check library for Node.js and TypeScript. Liveness and readiness checks with popular server integrations.",
   "homepage": "https://medicus.js.org",
   "keywords": [
     "health check",
@@ -18,6 +18,10 @@
     "heartbeat",
     "fastify",
     "fastify-plugin",
+    "elysia",
+    "express",
+    "h3",
+    "nitro",
     "hono",
     "tanstack-start",
     "avvio",
@@ -73,9 +77,13 @@
     "@nolebase/vitepress-plugin-og-image": "^2.18.2",
     "@shikijs/vitepress-twoslash": "^4.3.1",
     "@tanstack/react-start": "^1.168.32",
+    "@types/express": "^5.0.6",
     "@types/node": "^26.1.1",
     "c8": "^12.0.0",
     "close-with-grace": "^2.5.0",
+    "elysia": "1.4.29",
+    "express": "5.2.1",
+    "h3": "1.15.11",
     "hono": "^4.12.31",
     "husky": "^9.1.7",
     "tsx": "^4.23.1",
@@ -84,20 +92,36 @@
     "vitepress-plugin-llms": "^1.13.3"
   },
   "peerDependencies": {
+    "@types/express": "^5.0.0 || ^4.17.0",
     "avvio": "^9.3.0",
+    "elysia": "^1.4.29",
+    "express": "^5.2.1 || ^4.21.0",
     "fastify": "^5.10.0",
     "fastify-plugin": "^6.0.0 || ^5.1.0",
+    "h3": "^1.15.11 || >=2.0.0-0 <3",
     "hono": "^4.12.31",
     "pino": "^10.3.1"
   },
   "peerDependenciesMeta": {
+    "@types/express": {
+      "optional": true
+    },
     "avvio": {
+      "optional": true
+    },
+    "elysia": {
+      "optional": true
+    },
+    "express": {
       "optional": true
     },
     "fastify": {
       "optional": true
     },
     "fastify-plugin": {
+      "optional": true
+    },
+    "h3": {
       "optional": true
     },
     "hono": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medicus",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Flexible, framework-agnostic health check library for Node.js and TypeScript. Liveness and readiness checks with popular server integrations.",
   "homepage": "https://medicus.js.org",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@tanstack/react-start':
         specifier: ^1.168.32
         version: 1.168.32(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.40.1)(supports-color@7.2.0)(vite@5.4.19(@types/node@26.1.1)(lightningcss@1.32.0))
+      '@types/express':
+        specifier: ^5.0.6
+        version: 5.0.6
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -57,6 +60,15 @@ importers:
       close-with-grace:
         specifier: ^2.5.0
         version: 2.5.0
+      elysia:
+        specifier: 1.4.29
+        version: 1.4.29(@sinclair/typebox@0.34.52)(exact-mirror@1.2.2)(file-type@22.0.1(supports-color@7.2.0))(openapi-types@12.1.3)(typescript@6.0.3)
+      express:
+        specifier: 5.2.1
+        version: 5.2.1(supports-color@7.2.0)
+      h3:
+        specifier: 1.15.11
+        version: 1.15.11
       hono:
         specifier: ^4.12.31
         version: 4.12.31
@@ -304,6 +316,9 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
   '@docsearch/css@3.8.2':
     resolution: {integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==}
@@ -1015,14 +1030,36 @@ packages:
     resolution: {integrity: sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA==}
     engines: {node: '>=20.19'}
 
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
+  '@types/express-serve-static-core@5.1.2':
+    resolution: {integrity: sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -1044,6 +1081,18 @@ packages:
 
   '@types/node@26.1.1':
     resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
+
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -1165,6 +1214,10 @@ packages:
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -1237,6 +1290,10 @@ packages:
   birpc@2.3.0:
     resolution: {integrity: sha512-ijbtkn/F3Pvzb6jHypHRyve2QApOCZDR25D/VnkY2G/lBNcXCTsnsCxgY4k4PkVB7zfwzYbY3O9Lcqe3xufS5g==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -1249,6 +1306,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   c8@12.0.0:
     resolution: {integrity: sha512-4zpJvrd1nKWutnnKC2pXkFmb6iM1l+ffN//o1CzlTNwW7GSOs9a1xrLqkC48nU8oEkjmPZLPiwMsIaOvoF4Pqg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
@@ -1258,6 +1319,14 @@ packages:
     peerDependenciesMeta:
       monocart-coverage-reports:
         optional: true
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   caniuse-lite@1.0.30001806:
     resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
@@ -1314,14 +1383,41 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-es@1.2.3:
+    resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
 
   cookie-es@3.1.1:
     resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   cookie@1.0.1:
     resolution: {integrity: sha512-Xd8lFX4LM9QEEwxQpF9J9NTUh8pmdJO0cyRJhFiDoLTk2eH8FXlRv2IFGYVadZpqI3j8fhNrSdKCeYPxiAhLXw==}
+    engines: {node: '>=18'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
   copy-anything@3.0.5:
@@ -1331,6 +1427,9 @@ packages:
   cross-spawn@7.0.5:
     resolution: {integrity: sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==}
     engines: {node: '>= 8'}
+
+  crossws@0.3.5:
+    resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
 
   css-selector-parser@3.3.0:
     resolution: {integrity: sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==}
@@ -1353,9 +1452,16 @@ packages:
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1372,8 +1478,30 @@ packages:
     resolution: {integrity: sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==}
     hasBin: true
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.393:
     resolution: {integrity: sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==}
+
+  elysia@1.4.29:
+    resolution: {integrity: sha512-GwMRGGwSdjfPt+w3LA0fqTuYJtS8uVRJicvoar98/HrO5qdFKDc9CwjIb6Kja+v39lkY+58hr2JvdR9jQzlUuA==}
+    peerDependencies:
+      '@sinclair/typebox': '>= 0.34.0 < 1'
+      '@types/bun': '>= 1.2.0'
+      exact-mirror: '>= 0.0.9'
+      file-type: '>= 20.0.0'
+      openapi-types: '>= 12.0.0'
+      typescript: '>= 5.0.0'
+    peerDependenciesMeta:
+      '@types/bun':
+        optional: true
+      typescript:
+        optional: true
 
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
@@ -1383,6 +1511,10 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -1395,6 +1527,18 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -1410,6 +1554,9 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
@@ -1421,6 +1568,22 @@ packages:
 
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  exact-mirror@1.2.2:
+    resolution: {integrity: sha512-jUlRkZOPN3rCAy4kmZeD2HCnoXwJ6KlWNkEBJ3sEJ2rbLSU+tN60hY7XzPZkImRQOJczllvOBYTYEJTYScPh5Q==}
+    peerDependencies:
+      typebox: '>= 1.1.0'
+    peerDependenciesMeta:
+      typebox:
+        optional: true
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   exsolve@1.1.0:
     resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
@@ -1480,6 +1643,14 @@ packages:
   fetchdts@0.1.7:
     resolution: {integrity: sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==}
 
+  file-type@22.0.1:
+    resolution: {integrity: sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==}
+    engines: {node: '>=22'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way@9.6.0:
     resolution: {integrity: sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==}
     engines: {node: '>=20'}
@@ -1508,6 +1679,14 @@ packages:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fs-extra@11.3.6:
     resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
     engines: {node: '>=14.14'}
@@ -1516,6 +1695,9 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -1529,9 +1711,21 @@ packages:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1539,6 +1733,9 @@ packages:
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
+
+  h3@1.15.11:
+    resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
 
   h3@2.0.1-rc.20:
     resolution: {integrity: sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==}
@@ -1553,6 +1750,14 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
 
   hast-util-from-html@2.0.3:
     resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
@@ -1597,14 +1802,35 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
 
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   ipaddr.js@2.2.0:
     resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
     engines: {node: '>= 10'}
+
+  iron-webcrypto@1.2.1:
+    resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
   is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
@@ -1621,6 +1847,9 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-unicode-supported@1.3.0:
     resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
@@ -1821,6 +2050,10 @@ packages:
     resolution: {integrity: sha512-MqIQVVkz+uGEHi3TsHx/czcxxCbRIL7sv5K5DnYw/tI+apY54IbPefV/cmgxp6LoJSEx/TqcHdLs/298afG5QQ==}
     engines: {node: '>=6'}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
 
@@ -1862,6 +2095,17 @@ packages:
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  memoirist@0.4.0:
+    resolution: {integrity: sha512-zxTgA0mSYELa66DimuNQDvyLq36AwDlTuVRbnQtB+VuTcKWm5Qc4z3WkSpgsFWHNhexqkIooqpv4hdcqrX5Nmg==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -1933,6 +2177,14 @@ packages:
     resolution: {integrity: sha512-H/E3J6t+DQs/F2YgfDhxUVZz/dF8JXPPKTLHL/yHCcLZLtCXJDUaqvhJXQwqOVBvbyNn4T0WjLpIHd7PAw7fBA==}
     hasBin: true
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
@@ -1962,6 +2214,13 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  node-mock-http@1.0.4:
+    resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
+
   node-releases@2.0.51:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
     engines: {node: '>=18'}
@@ -1969,12 +2228,23 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -1988,6 +2258,9 @@ packages:
 
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
   ora@8.2.0:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
@@ -2003,6 +2276,10 @@ packages:
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -2021,6 +2298,9 @@ packages:
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2070,12 +2350,31 @@ packages:
   property-information@7.0.0:
     resolution: {integrity: sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
 
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  radix3@1.1.2:
+    resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -2161,6 +2460,10 @@ packages:
   rou3@0.8.1:
     resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-regex2@5.1.1:
     resolution: {integrity: sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==}
     hasBin: true
@@ -2168,6 +2471,9 @@ packages:
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -2191,6 +2497,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   seroval-plugins@1.5.5:
     resolution: {integrity: sha512-+BDhqYM6CEn3x09v44dpa9p6974FuUB2dxk+Ctn04k0cO1Zt6QODTXfmEZK0eBaTe/fJBvP4NMGuNJ+R8T+QMg==}
     engines: {node: '>=10'}
@@ -2201,8 +2511,15 @@ packages:
     resolution: {integrity: sha512-bSjOuPcwPKLSJNhr9+bZxA20nQxVle5J5MNsYRVE6cIg7KpRLXGupymePavu0jrxlPiPsr4xGZSB8yUY2sH2sw==}
     engines: {node: '>=10'}
 
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2218,6 +2535,22 @@ packages:
   shiki@4.3.1:
     resolution: {integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==}
     engines: {node: '>=20'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -2253,6 +2586,10 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
     engines: {node: '>=18'}
@@ -2280,6 +2617,10 @@ packages:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
 
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
+
   superjson@2.2.2:
     resolution: {integrity: sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==}
     engines: {node: '>=16'}
@@ -2306,6 +2647,14 @@ packages:
   toad-cache@3.7.0:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
 
   tokenx@1.3.0:
     resolution: {integrity: sha512-NLdXTEZkKiO0gZuLtMoZKjCXTREXeZZt8nnnNeyoXtNZAfG/GKGSbQtLU5STspc0rMSwcA+UJfWZkbNU01iKmQ==}
@@ -2337,6 +2686,10 @@ packages:
     peerDependencies:
       typescript: ^5.5.0 || ^6.0.0
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -2347,6 +2700,13 @@ packages:
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
+
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
@@ -2375,6 +2735,10 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   unplugin@3.3.0:
     resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
@@ -2423,6 +2787,10 @@ packages:
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -2519,6 +2887,9 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   xmlbuilder2@4.0.3:
     resolution: {integrity: sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA==}
@@ -2829,6 +3200,8 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.5.4':
     optional: true
+
+  '@borewit/text-codec@0.2.2': {}
 
   '@docsearch/css@3.8.2': {}
 
@@ -3491,15 +3864,48 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.162.0': {}
 
+  '@tokenizer/inflate@0.4.1(supports-color@7.2.0)':
+    dependencies:
+      debug: 4.4.3(supports-color@7.2.0)
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 26.1.1
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 26.1.1
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
 
   '@types/estree@1.0.7': {}
 
+  '@types/express-serve-static-core@5.1.2':
+    dependencies:
+      '@types/node': 26.1.1
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.2
+      '@types/serve-static': 2.2.0
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -3521,6 +3927,19 @@ snapshots:
   '@types/node@26.1.1':
     dependencies:
       undici-types: 8.3.0
+
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 26.1.1
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 26.1.1
 
   '@types/unist@3.0.3': {}
 
@@ -3657,6 +4076,11 @@ snapshots:
 
   abstract-logging@2.0.1: {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
@@ -3730,6 +4154,20 @@ snapshots:
 
   birpc@2.3.0: {}
 
+  body-parser@2.3.0(supports-color@7.2.0):
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3(supports-color@7.2.0)
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boolbase@1.0.0: {}
 
   brace-expansion@5.0.6:
@@ -3744,6 +4182,8 @@ snapshots:
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.6)
 
+  bytes@3.1.2: {}
+
   c8@12.0.0:
     dependencies:
       '@bcoe/v8-coverage': 1.0.1
@@ -3757,6 +4197,16 @@ snapshots:
       v8-to-istanbul: 9.3.0
       yargs: 18.0.0
       yargs-parser: 21.1.1
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001806: {}
 
@@ -3804,11 +4254,25 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-es@1.2.3: {}
 
   cookie-es@3.1.1: {}
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   cookie@1.0.1: {}
+
+  cookie@1.1.1: {}
 
   copy-anything@3.0.5:
     dependencies:
@@ -3819,6 +4283,10 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  crossws@0.3.5:
+    dependencies:
+      uncrypto: 0.1.3
 
   css-selector-parser@3.3.0: {}
 
@@ -3836,7 +4304,11 @@ snapshots:
 
   defu@6.1.7: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
+
+  destr@2.0.5: {}
 
   detect-libc@2.1.2: {}
 
@@ -3848,7 +4320,27 @@ snapshots:
 
   direction@2.0.1: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.393: {}
+
+  elysia@1.4.29(@sinclair/typebox@0.34.52)(exact-mirror@1.2.2)(file-type@22.0.1(supports-color@7.2.0))(openapi-types@12.1.3)(typescript@6.0.3):
+    dependencies:
+      '@sinclair/typebox': 0.34.52
+      cookie: 1.1.1
+      exact-mirror: 1.2.2
+      fast-decode-uri-component: 1.0.1
+      file-type: 22.0.1(supports-color@7.2.0)
+      memoirist: 0.4.0
+      openapi-types: 12.1.3
+    optionalDependencies:
+      typescript: 6.0.3
 
   emoji-regex-xs@1.0.0: {}
 
@@ -3856,11 +4348,21 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
+  encodeurl@2.0.0: {}
+
   entities@4.5.0: {}
 
   entities@6.0.1: {}
 
   entities@7.0.1: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -3919,11 +4421,50 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@5.0.0: {}
 
   esprima@4.0.1: {}
 
   estree-walker@2.0.2: {}
+
+  etag@1.8.1: {}
+
+  exact-mirror@1.2.2: {}
+
+  express@5.2.1(supports-color@7.2.0):
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0(supports-color@7.2.0)
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3(supports-color@7.2.0)
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1(supports-color@7.2.0)
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0(supports-color@7.2.0)
+      send: 1.2.1(supports-color@7.2.0)
+      serve-static: 2.2.1(supports-color@7.2.0)
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   exsolve@1.1.0: {}
 
@@ -4000,6 +4541,26 @@ snapshots:
 
   fetchdts@0.1.7: {}
 
+  file-type@22.0.1(supports-color@7.2.0):
+    dependencies:
+      '@tokenizer/inflate': 0.4.1(supports-color@7.2.0)
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  finalhandler@2.1.1(supports-color@7.2.0):
+    dependencies:
+      debug: 4.4.3(supports-color@7.2.0)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-my-way@9.6.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4028,6 +4589,10 @@ snapshots:
 
   format@0.2.2: {}
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fs-extra@11.3.6:
     dependencies:
       graceful-fs: 4.2.11
@@ -4037,17 +4602,39 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
+
+  gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
 
@@ -4058,12 +4645,30 @@ snapshots:
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
 
+  h3@1.15.11:
+    dependencies:
+      cookie-es: 1.2.3
+      crossws: 0.3.5
+      defu: 6.1.7
+      destr: 2.0.5
+      iron-webcrypto: 1.2.1
+      node-mock-http: 1.0.4
+      radix3: 1.1.2
+      ufo: 1.6.4
+      uncrypto: 0.1.3
+
   h3@2.0.1-rc.20:
     dependencies:
       rou3: 0.8.1
       srvx: 0.11.22
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
 
   hast-util-from-html@2.0.3:
     dependencies:
@@ -4156,9 +4761,29 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   husky@9.1.7: {}
 
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
+
+  inherits@2.0.4: {}
+
+  ipaddr.js@1.9.1: {}
+
   ipaddr.js@2.2.0: {}
+
+  iron-webcrypto@1.2.1: {}
 
   is-extendable@0.1.1: {}
 
@@ -4167,6 +4792,8 @@ snapshots:
   is-interactive@2.0.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-promise@4.0.0: {}
 
   is-unicode-supported@1.3.0: {}
 
@@ -4331,6 +4958,8 @@ snapshots:
 
   markdown-title@1.0.2: {}
 
+  math-intrinsics@1.1.0: {}
+
   mdast-util-find-and-replace@3.0.2:
     dependencies:
       '@types/mdast': 4.0.4
@@ -4457,6 +5086,12 @@ snapshots:
       '@types/mdast': 4.0.4
 
   mdurl@2.0.0: {}
+
+  media-typer@1.1.0: {}
+
+  memoirist@0.4.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -4602,6 +5237,12 @@ snapshots:
     dependencies:
       yargs: 17.7.2
 
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mimic-function@5.0.1: {}
 
   minimatch@10.2.5:
@@ -4620,15 +5261,29 @@ snapshots:
 
   nanoid@3.3.16: {}
 
+  negotiator@1.0.0: {}
+
+  node-mock-http@1.0.4: {}
+
   node-releases@2.0.51: {}
 
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
 
+  object-inspect@1.13.4: {}
+
   ohash@2.0.11: {}
 
   on-exit-leak-free@2.1.2: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@7.0.0:
     dependencies:
@@ -4647,6 +5302,8 @@ snapshots:
       oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  openapi-types@12.1.3: {}
 
   ora@8.2.0:
     dependencies:
@@ -4672,6 +5329,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
@@ -4684,6 +5343,8 @@ snapshots:
       minipass: 7.1.3
 
   path-to-regexp@6.3.0: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -4731,9 +5392,30 @@ snapshots:
 
   property-information@7.0.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   punycode.js@2.3.1: {}
 
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   quick-format-unescaped@4.0.4: {}
+
+  radix3@1.1.2: {}
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -4864,11 +5546,23 @@ snapshots:
 
   rou3@0.8.1: {}
 
+  router@2.2.0(supports-color@7.2.0):
+    dependencies:
+      debug: 4.4.3(supports-color@7.2.0)
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   safe-regex2@5.1.1:
     dependencies:
       ret: 0.5.0
 
   safe-stable-stringify@2.5.0: {}
+
+  safer-buffer@2.1.2: {}
 
   scheduler@0.23.2:
     dependencies:
@@ -4887,13 +5581,40 @@ snapshots:
 
   semver@7.6.3: {}
 
+  send@1.2.1(supports-color@7.2.0):
+    dependencies:
+      debug: 4.4.3(supports-color@7.2.0)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   seroval-plugins@1.5.5(seroval@1.5.5):
     dependencies:
       seroval: 1.5.5
 
   seroval@1.5.5: {}
 
+  serve-static@2.2.1(supports-color@7.2.0):
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
   set-cookie-parser@2.7.1: {}
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -4923,6 +5644,34 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   signal-exit@4.1.0: {}
 
   sonic-boom@4.2.0:
@@ -4942,6 +5691,8 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   srvx@0.11.22: {}
+
+  statuses@2.0.2: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -4972,6 +5723,10 @@ snapshots:
 
   strip-bom-string@1.0.0: {}
 
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
   superjson@2.2.2:
     dependencies:
       copy-anything: 3.0.5
@@ -4998,6 +5753,14 @@ snapshots:
       picomatch: 4.0.4
 
   toad-cache@3.7.0: {}
+
+  toidentifier@1.0.1: {}
+
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
 
   tokenx@1.3.0: {}
 
@@ -5032,11 +5795,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
 
   ufo@1.6.4: {}
+
+  uint8array-extras@1.5.0: {}
+
+  uncrypto@0.1.3: {}
 
   undici-types@8.3.0: {}
 
@@ -5081,6 +5854,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpipe@1.0.0: {}
+
   unplugin@3.3.0(esbuild@0.28.1)(rollup@4.40.1)(vite@5.4.19(@types/node@26.1.1)(lightningcss@1.32.0)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -5106,6 +5881,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
+
+  vary@1.1.2: {}
 
   vfile-location@5.0.3:
     dependencies:
@@ -5237,6 +6014,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  wrappy@1.0.2: {}
 
   xmlbuilder2@4.0.3:
     dependencies:

--- a/src/integrations/elysia.ts
+++ b/src/integrations/elysia.ts
@@ -1,0 +1,61 @@
+import type { Context } from 'elysia';
+import { Medicus } from '../medicus';
+import type { MedicusOption } from '../types';
+import { createHealthCheckHeaders, parseHealthStatus, performHttpCheck } from '../utils/http';
+
+export interface ElysiaHealthCheckOptions {
+  /** Whether to include debug information in the response by default */
+  debug?: boolean;
+
+  /**
+   * Custom response headers
+   *
+   * @default DefaultHealthCheckHeaders
+   */
+  headers?: Record<string, string>;
+}
+
+export type ElysiaMedicusOptions = Omit<MedicusOption<Context>, 'context'> &
+  ElysiaHealthCheckOptions;
+
+export interface ElysiaHealthCheckHandler {
+  (this: void, context: Context): Promise<Response>;
+
+  /** The underlying Medicus instance, useful for registration and shutdown */
+  medicus: Medicus<Context>;
+}
+
+/**
+ * Creates an Elysia route handler for a health check endpoint.
+ *
+ * @example
+ * ```ts
+ * app.get('/health', createElysiaHealthCheckHandler({
+ *   checkers: { database: () => HealthStatus.HEALTHY }
+ * }));
+ * ```
+ */
+export function createElysiaHealthCheckHandler({
+  debug,
+  headers,
+  ...medicusOptions
+}: ElysiaMedicusOptions = {}): ElysiaHealthCheckHandler {
+  const defaultDebug = !!debug;
+  const defaultHeaders = createHealthCheckHeaders(headers);
+  const medicus = new Medicus<Context>(medicusOptions);
+
+  const handler = async function elysiaHealthCheckHandler(context: Context): Promise<Response> {
+    const last = !!context.query.last;
+    const isDebug = !!context.query.debug || defaultDebug;
+    const simulate = parseHealthStatus(context.query.simulate);
+    const check = await performHttpCheck(medicus, isDebug, last, simulate, context);
+
+    return new Response(JSON.stringify(check.result), {
+      status: check.status,
+      headers: defaultHeaders
+    });
+  } as ElysiaHealthCheckHandler;
+
+  handler.medicus = medicus;
+  return handler;
+}

--- a/src/integrations/express.ts
+++ b/src/integrations/express.ts
@@ -1,0 +1,67 @@
+import type { Request, RequestHandler } from 'express';
+import { Medicus } from '../medicus';
+import type { MedicusOption } from '../types';
+import { createHealthCheckHeaders, parseHealthStatus, performHttpCheck } from '../utils/http';
+
+export interface ExpressHealthCheckOptions {
+  /** Whether to include debug information in the response by default */
+  debug?: boolean;
+
+  /**
+   * Custom response headers
+   *
+   * @default DefaultHealthCheckHeaders
+   */
+  headers?: Record<string, string>;
+}
+
+export type ExpressMedicusOptions = Omit<MedicusOption<Request>, 'context'> &
+  ExpressHealthCheckOptions;
+
+export interface ExpressHealthCheckHandler extends RequestHandler {
+  /** The underlying Medicus instance, useful for registration and shutdown */
+  medicus: Medicus<Request>;
+}
+
+/**
+ * Creates an Express route handler for a health check endpoint.
+ *
+ * @example
+ * ```ts
+ * app.get('/health', createExpressHealthCheckHandler({
+ *   checkers: { database: () => HealthStatus.HEALTHY }
+ * }));
+ * ```
+ */
+export function createExpressHealthCheckHandler({
+  debug,
+  headers,
+  ...medicusOptions
+}: ExpressMedicusOptions = {}): ExpressHealthCheckHandler {
+  const defaultDebug = !!debug;
+  const defaultHeaders = createHealthCheckHeaders(headers);
+  const medicus = new Medicus<Request>(medicusOptions);
+
+  const handler: ExpressHealthCheckHandler = async function expressHealthCheckHandler(
+    req,
+    res,
+    next
+  ) {
+    try {
+      const last = !!req.query.last;
+      const isDebug = !!req.query.debug || defaultDebug;
+      const simulate = parseHealthStatus(
+        typeof req.query.simulate === 'string' ? req.query.simulate : undefined
+      );
+      const check = await performHttpCheck(medicus, isDebug, last, simulate, req);
+
+      res.set(defaultHeaders).status(check.status).json(check.result);
+    } catch (error) {
+      // Express 4 does not automatically forward rejected handler promises.
+      next(error);
+    }
+  };
+
+  handler.medicus = medicus;
+  return handler;
+}

--- a/src/integrations/fastify.ts
+++ b/src/integrations/fastify.ts
@@ -3,8 +3,13 @@ import fp from 'fastify-plugin';
 import type { Logger } from 'pino';
 import { Medicus } from '../medicus';
 import { HealthCheckQueryParamsSchema, HealthCheckResultSchema } from '../schemas';
-import { type HealthCheckResult, HealthStatus, type MedicusOption } from '../types';
-import { HttpStatuses, parseHealthStatus, performHttpCheck } from '../utils/http';
+import { HealthStatus, type MedicusOption } from '../types';
+import {
+  createHealthCheckHeaders,
+  HttpStatuses,
+  parseHealthStatus,
+  performHttpCheck
+} from '../utils/http';
 import { pinoMedicusPlugin } from './pino';
 
 declare module 'fastify' {
@@ -34,6 +39,13 @@ export type FastifyMedicsPluginOptions = Omit<
    * @default false
    */
   debug?: DebugDetector;
+
+  /**
+   * Custom response headers to include in health check responses
+   *
+   * @default DefaultHealthCheckHeaders
+   */
+  headers?: Record<string, string>;
 };
 
 /**
@@ -52,7 +64,8 @@ export type FastifyMedicsPluginOptions = Omit<
  * ```
  */
 export const fastifyMedicusPlugin = fp<FastifyMedicsPluginOptions>(
-  async (fastify, { route, debug = false, ...medicusOptions }) => {
+  async (fastify, { route, debug = false, headers, ...medicusOptions }) => {
+    const responseHeaders = createHealthCheckHeaders(headers);
     // Adds fastify error logger
     medicusOptions.plugins ??= [];
     medicusOptions.plugins.push(pinoMedicusPlugin(fastify.log as Logger));
@@ -101,7 +114,7 @@ export const fastifyMedicusPlugin = fp<FastifyMedicsPluginOptions>(
           // https://github.com/fastify/otel#usage
           otel: false
         },
-        async handler(request, reply): Promise<HealthCheckResult> {
+        async handler(request, reply) {
           const isDebug = typeof debug === 'boolean' ? debug : await debug(request);
 
           //@ts-expect-error - untyped from querystring
@@ -117,8 +130,7 @@ export const fastifyMedicusPlugin = fp<FastifyMedicsPluginOptions>(
             simulate
           );
 
-          reply.status(status);
-          return result;
+          return reply.headers(responseHeaders).status(status).send(JSON.stringify(result));
         }
       });
     }

--- a/src/integrations/h3.ts
+++ b/src/integrations/h3.ts
@@ -1,0 +1,67 @@
+import type { H3Event } from 'h3';
+import { Medicus } from '../medicus';
+import type { MedicusOption } from '../types';
+import { createHealthCheckHeaders, parseHealthStatus, performHttpCheck } from '../utils/http';
+
+export interface H3HealthCheckOptions {
+  /** Whether to include debug information in the response by default */
+  debug?: boolean;
+
+  /**
+   * Custom response headers
+   *
+   * @default DefaultHealthCheckHeaders
+   */
+  headers?: Record<string, string>;
+}
+
+export type H3MedicusOptions = Omit<MedicusOption<H3Event>, 'context'> & H3HealthCheckOptions;
+
+export interface H3HealthCheckHandler {
+  (this: void, event: H3Event): Promise<Response>;
+
+  /** The underlying Medicus instance, useful for registration and shutdown */
+  medicus: Medicus<H3Event>;
+}
+
+/**
+ * Creates an H3 event handler that can also be exported directly from a Nitro route.
+ *
+ * The handler returns a Web Response, which is supported by H3 1/Nitro 2 and is
+ * the native response model in H3 2/Nitro 3.
+ */
+export function createH3HealthCheckHandler({
+  debug,
+  headers,
+  ...medicusOptions
+}: H3MedicusOptions = {}): H3HealthCheckHandler {
+  const defaultDebug = !!debug;
+  const defaultHeaders = createHealthCheckHeaders(headers);
+  const medicus = new Medicus<H3Event>(medicusOptions);
+
+  const handler = async function h3HealthCheckHandler(event: H3Event): Promise<Response> {
+    const url = getEventUrl(event);
+    const last = url.searchParams.has('last');
+    const isDebug = url.searchParams.has('debug') || defaultDebug;
+    const simulate = parseHealthStatus(url.searchParams.get('simulate'));
+    const check = await performHttpCheck(medicus, isDebug, last, simulate, event);
+
+    return new Response(JSON.stringify(check.result), {
+      status: check.status,
+      headers: defaultHeaders
+    });
+  } as H3HealthCheckHandler;
+
+  handler.medicus = medicus;
+  return handler;
+}
+
+function getEventUrl(event: H3Event): URL {
+  // H3 2 exposes `event.url`; H3 1 and stable Nitro expose `event.node.req.url`.
+  const modernEvent = event as H3Event & { url?: URL };
+  if (modernEvent.url) {
+    return modernEvent.url;
+  }
+
+  return new URL(event.node.req.url || '/', 'http://localhost');
+}

--- a/src/integrations/hono.ts
+++ b/src/integrations/hono.ts
@@ -1,7 +1,7 @@
 import type { Context, Env, Handler, Input } from 'hono';
 import { Medicus } from '../medicus';
 import type { MedicusOption } from '../types';
-import { parseHealthStatus, performHttpCheck } from '../utils/http';
+import { createHealthCheckHeaders, parseHealthStatus, performHttpCheck } from '../utils/http';
 
 export interface HonoHealthCheckOptions {
   /**
@@ -14,7 +14,7 @@ export interface HonoHealthCheckOptions {
   /**
    * Custom response headers to include in health check responses
    *
-   * @default { 'cache-control': 'no-cache, no-store, must-revalidate' }
+   * @default DefaultHealthCheckHeaders
    */
   headers?: Record<string, string>;
 }
@@ -104,10 +104,7 @@ export function createHonoHealthCheckHandler<
   ...medicusOptions
 }: HonoMedicusOptions<E, P, I> = {}): HonoHealthCheckHandler<E, P, I> {
   const defaultDebug = !!debug;
-  const defaultHeaders = {
-    'cache-control': 'no-cache, no-store, must-revalidate',
-    ...headers
-  };
+  const defaultHeaders = createHealthCheckHeaders(headers);
   const medicus = new Medicus<Context<MedicusVariables<E, P, I>, P, I>>(medicusOptions);
 
   return async function honoHealthCheckHandler(c) {
@@ -119,10 +116,12 @@ export function createHonoHealthCheckHandler<
 
     const check = await performHttpCheck(medicus, debug, last, simulate, c);
 
+    const response = c.json(check.result, check.status as 200 | 503);
+
     for (const [key, value] of Object.entries(defaultHeaders)) {
-      c.header(key, value);
+      response.headers.set(key, value);
     }
 
-    return c.json(check.result, check.status as 200 | 503);
+    return response;
   };
 }

--- a/src/integrations/http.ts
+++ b/src/integrations/http.ts
@@ -1,6 +1,6 @@
 import type { ServerResponse } from 'node:http';
 import type { Medicus } from '../medicus';
-import { parseHealthStatus, performHttpCheck } from '../utils/http';
+import { createHealthCheckHeaders, parseHealthStatus, performHttpCheck } from '../utils/http';
 
 export interface HttpHealthCheckOptions {
   /**
@@ -13,7 +13,7 @@ export interface HttpHealthCheckOptions {
   /**
    * Custom response headers to include in health check responses
    *
-   * @default { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-cache, no-store, must-revalidate' }
+   * @default DefaultHealthCheckHeaders
    */
   headers?: Record<string, string>;
 }
@@ -83,11 +83,7 @@ export function createHttpHealthCheckHandler<Ctx = void>(
   options: HttpHealthCheckOptions = {}
 ): HttpHealthCheckHandler {
   const defaultDebug = !!options.debug || false;
-  const defaultHeaders = {
-    'content-type': 'application/json; charset=utf-8',
-    'cache-control': 'no-cache, no-store, must-revalidate',
-    ...options.headers
-  };
+  const defaultHeaders = createHealthCheckHeaders(options.headers);
 
   return async function httpHealthCheckHandler(searchParams, res) {
     const last = !!searchParams.get('last');

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,6 +1,23 @@
 import type { Medicus } from '../medicus';
 import { type HealthCheckResult, HealthStatus } from '../types';
 
+/** Default headers sent by every HTTP health check integration. */
+export const DefaultHealthCheckHeaders = {
+  'cache-control': 'no-cache, no-store, must-revalidate',
+  'content-type': 'application/json; charset=utf-8'
+} as const;
+
+/** Creates health check response headers with optional user overrides. */
+export function createHealthCheckHeaders(headers?: Record<string, string>): Record<string, string> {
+  const merged = new Headers(DefaultHealthCheckHeaders);
+
+  for (const [name, value] of Object.entries(headers ?? {})) {
+    merged.set(name, value);
+  }
+
+  return Object.fromEntries(merged);
+}
+
 /**
  * Converts a health status to an HTTP status code
  */

--- a/test/integrations/elysia.test.ts
+++ b/test/integrations/elysia.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { Elysia } from 'elysia';
+import { HealthStatus, Medicus } from '../../src';
+import { createElysiaHealthCheckHandler } from '../../src/integrations/elysia';
+
+describe('Elysia Integration', () => {
+  it('mounts at the user-defined route and passes request context to checkers', async () => {
+    const handler = createElysiaHealthCheckHandler({
+      debug: true,
+      headers: { 'x-health': 'medicus' },
+      checkers: {
+        request(context) {
+          return {
+            status: HealthStatus.HEALTHY,
+            debug: { path: new URL(context.request.url).pathname }
+          };
+        }
+      }
+    });
+    const app = new Elysia().get('/ready', handler);
+
+    const response = await app.handle(new Request('http://localhost/ready'));
+    const missing = await app.handle(new Request('http://localhost/health'));
+    const body: any = await response.json();
+
+    assert.ok(handler.medicus instanceof Medicus);
+    assert.equal(response.status, 200);
+    assert.equal(missing.status, 404);
+    assert.equal(response.headers.get('cache-control'), 'no-cache, no-store, must-revalidate');
+    assert.equal(response.headers.get('content-type'), 'application/json; charset=utf-8');
+    assert.equal(response.headers.get('x-health'), 'medicus');
+    assert.equal(body.services.request.debug.path, '/ready');
+  });
+
+  it('supports debug, cached, and simulated results', async () => {
+    let calls = 0;
+    const handler = createElysiaHealthCheckHandler({
+      checkers: {
+        service() {
+          calls++;
+          return {
+            status: HealthStatus.HEALTHY,
+            debug: { visible: true }
+          };
+        }
+      }
+    });
+    const app = new Elysia().get('/health', handler);
+
+    const first = await app.handle(new Request('http://localhost/health?debug=true'));
+    const firstBody: any = await first.json();
+    const cached = await app.handle(new Request('http://localhost/health?last=true'));
+    const simulated = await app.handle(new Request('http://localhost/health?simulate=unhealthy'));
+
+    assert.equal(firstBody.services.service.debug.visible, true);
+    assert.equal(cached.status, 200);
+    assert.equal(calls, 2);
+    assert.equal(simulated.status, 503);
+  });
+
+  it('allows late checker registration through the handler', async () => {
+    const handler = createElysiaHealthCheckHandler();
+    handler.medicus.addChecker({ late: () => HealthStatus.DEGRADED });
+    const app = new Elysia().get('/health', handler);
+
+    const response = await app.handle(new Request('http://localhost/health'));
+
+    assert.equal(response.status, 200);
+    assert.equal(((await response.json()) as any).status, HealthStatus.DEGRADED);
+  });
+});

--- a/test/integrations/express.test.ts
+++ b/test/integrations/express.test.ts
@@ -12,6 +12,10 @@ describe('Express Integration', () => {
     await Promise.all(servers.map((server) => closeServer(server)));
   });
 
+  it('creates a handler without options', () => {
+    assert.ok(createExpressHealthCheckHandler().medicus instanceof Medicus);
+  });
+
   it('handles health requests with Express request context', async () => {
     const app = express();
     const handler = createExpressHealthCheckHandler({

--- a/test/integrations/express.test.ts
+++ b/test/integrations/express.test.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert';
+import type { Server } from 'node:http';
+import { after, describe, it } from 'node:test';
+import express, { type ErrorRequestHandler } from 'express';
+import { HealthStatus, Medicus } from '../../src';
+import { createExpressHealthCheckHandler } from '../../src/integrations/express';
+
+describe('Express Integration', () => {
+  const servers: Server[] = [];
+
+  after(async () => {
+    await Promise.all(servers.map((server) => closeServer(server)));
+  });
+
+  it('handles health requests with Express request context', async () => {
+    const app = express();
+    const handler = createExpressHealthCheckHandler({
+      debug: true,
+      headers: { 'x-health': 'medicus' },
+      checkers: {
+        request(context) {
+          return {
+            status: HealthStatus.HEALTHY,
+            debug: { path: context.path }
+          };
+        }
+      }
+    });
+    app.get('/health', handler);
+
+    const server = app.listen(0);
+    servers.push(server);
+    const response = await fetch(serverUrl(server, '/health'));
+    const body: any = await response.json();
+
+    assert.ok(handler.medicus instanceof Medicus);
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('cache-control'), 'no-cache, no-store, must-revalidate');
+    assert.equal(response.headers.get('content-type'), 'application/json; charset=utf-8');
+    assert.equal(response.headers.get('x-health'), 'medicus');
+    assert.equal(body.services.request.debug.path, '/health');
+  });
+
+  it('supports cached and simulated results', async () => {
+    let calls = 0;
+    const app = express();
+    const handler = createExpressHealthCheckHandler({
+      checkers: {
+        service() {
+          calls++;
+          return HealthStatus.HEALTHY;
+        }
+      }
+    });
+    app.get('/health', handler);
+
+    const server = app.listen(0);
+    servers.push(server);
+    await fetch(serverUrl(server, '/health'));
+    const cached = await fetch(serverUrl(server, '/health?last=true'));
+    const simulated = await fetch(serverUrl(server, '/health?simulate=unhealthy'));
+
+    assert.equal(cached.status, 200);
+    assert.equal(calls, 2);
+    assert.equal(simulated.status, 503);
+    assert.equal(((await simulated.json()) as any).status, HealthStatus.UNHEALTHY);
+  });
+
+  it('forwards unexpected failures to Express error middleware', async () => {
+    const app = express();
+    const handler = createExpressHealthCheckHandler({
+      unhealthyLogger() {
+        throw new Error('logger failed');
+      },
+      checkers: { service: () => HealthStatus.UNHEALTHY }
+    });
+    app.get('/health', handler);
+    const errorHandler: ErrorRequestHandler = (_error, _req, res, _next) => {
+      res.status(500).json({ handled: true });
+    };
+    app.use(errorHandler);
+
+    const server = app.listen(0);
+    servers.push(server);
+    const response = await fetch(serverUrl(server, '/health'));
+
+    assert.equal(response.status, 500);
+    assert.deepEqual(await response.json(), { handled: true });
+  });
+});
+
+function serverUrl(server: Server, path: string): string {
+  const address = server.address();
+  assert.ok(address && typeof address !== 'string');
+  return `http://127.0.0.1:${address.port}${path}`;
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}

--- a/test/integrations/fastify.test.ts
+++ b/test/integrations/fastify.test.ts
@@ -7,7 +7,9 @@ import { fastifyMedicusPlugin } from '../../src/integrations/fastify';
 describe('medicusPlugin()', () => {
   it('registers a health check route', async () => {
     await using app = fastify();
-    await app.register(fastifyMedicusPlugin);
+    await app.register(fastifyMedicusPlugin, {
+      headers: { 'x-health': 'medicus' }
+    });
 
     assert.ok(app.medicus instanceof Medicus);
 
@@ -20,6 +22,9 @@ describe('medicusPlugin()', () => {
       status: HealthStatus.HEALTHY,
       services: {}
     });
+    assert.equal(response.headers['cache-control'], 'no-cache, no-store, must-revalidate');
+    assert.equal(response.headers['content-type'], 'application/json; charset=utf-8');
+    assert.equal(response.headers['x-health'], 'medicus');
   });
 
   it('uses cached version when ?last=true', async () => {
@@ -53,6 +58,26 @@ describe('medicusPlugin()', () => {
 
     assert.deepStrictEqual(response2.json(), {
       // cached
+      status: HealthStatus.HEALTHY,
+      services: {}
+    });
+  });
+
+  it('supports case-insensitive header overrides', async () => {
+    await using app = fastify();
+    await app.register(fastifyMedicusPlugin, {
+      headers: {
+        'Cache-Control': 'public, max-age=30',
+        'Content-Type': 'application/health+json'
+      }
+    });
+
+    const response = await app.inject('/health');
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.headers['cache-control'], 'public, max-age=30');
+    assert.equal(response.headers['content-type'], 'application/health+json; charset=utf-8');
+    assert.deepEqual(response.json(), {
       status: HealthStatus.HEALTHY,
       services: {}
     });

--- a/test/integrations/h3.test.ts
+++ b/test/integrations/h3.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { createApp, toWebHandler } from 'h3';
+import { HealthStatus, Medicus } from '../../src';
+import { createH3HealthCheckHandler } from '../../src/integrations/h3';
+
+describe('H3 and Nitro Integration', () => {
+  it('handles H3 requests and passes the event to checkers', async () => {
+    const handler = createH3HealthCheckHandler({
+      debug: true,
+      headers: { 'x-health': 'medicus' },
+      checkers: {
+        request(event) {
+          return {
+            status: HealthStatus.HEALTHY,
+            debug: { path: event.path }
+          };
+        }
+      }
+    });
+    const app = createApp().use(handler);
+    const response = await toWebHandler(app)(new Request('http://localhost/health'));
+    const body: any = await response.json();
+
+    assert.ok(handler.medicus instanceof Medicus);
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('cache-control'), 'no-cache, no-store, must-revalidate');
+    assert.equal(response.headers.get('content-type'), 'application/json; charset=utf-8');
+    assert.equal(response.headers.get('x-health'), 'medicus');
+    assert.equal(body.services.request.debug.path, '/health');
+  });
+
+  it('supports debug, cached, and simulated results', async () => {
+    let calls = 0;
+    const handler = createH3HealthCheckHandler({
+      checkers: {
+        service() {
+          calls++;
+          return {
+            status: HealthStatus.HEALTHY,
+            debug: { visible: true }
+          };
+        }
+      }
+    });
+    const app = createApp().use(handler);
+    const request = toWebHandler(app);
+
+    const first = await request(new Request('http://localhost/health?debug=true'));
+    const firstBody: any = await first.json();
+    const cached = await request(new Request('http://localhost/health?last=true'));
+    const simulated = await request(new Request('http://localhost/health?simulate=unhealthy'));
+
+    assert.equal(firstBody.services.service.debug.visible, true);
+    assert.equal(cached.status, 200);
+    assert.equal(calls, 2);
+    assert.equal(simulated.status, 503);
+  });
+});

--- a/test/integrations/h3.test.ts
+++ b/test/integrations/h3.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
-import { createApp, toWebHandler } from 'h3';
+import { createApp, type H3Event, toWebHandler } from 'h3';
 import { HealthStatus, Medicus } from '../../src';
 import { createH3HealthCheckHandler } from '../../src/integrations/h3';
 
@@ -55,5 +55,22 @@ describe('H3 and Nitro Integration', () => {
     assert.equal(cached.status, 200);
     assert.equal(calls, 2);
     assert.equal(simulated.status, 503);
+  });
+
+  it('supports H3 2 event URLs and the legacy empty URL fallback', async () => {
+    const modernHandler = createH3HealthCheckHandler({
+      checkers: { service: () => HealthStatus.HEALTHY }
+    });
+    const modernResponse = await modernHandler({
+      url: new URL('http://localhost/health?simulate=unhealthy')
+    } as unknown as H3Event);
+
+    const legacyHandler = createH3HealthCheckHandler();
+    const legacyResponse = await legacyHandler({
+      node: { req: { url: undefined } }
+    } as unknown as H3Event);
+
+    assert.equal(modernResponse.status, 503);
+    assert.equal(legacyResponse.status, 200);
   });
 });

--- a/test/integrations/hono.test.ts
+++ b/test/integrations/hono.test.ts
@@ -20,6 +20,7 @@ describe('Hono Integration', () => {
 
     assert.equal(response.status, 200);
     assert.equal(response.headers.get('cache-control'), 'no-cache, no-store, must-revalidate');
+    assert.equal(response.headers.get('content-type'), 'application/json; charset=utf-8');
 
     const body: any = await response.json();
     assert.equal(body.status, HealthStatus.HEALTHY);

--- a/test/utils/http.test.ts
+++ b/test/utils/http.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { createHealthCheckHeaders, DefaultHealthCheckHeaders } from '../../src/utils/http';
+
+describe('HTTP utilities', () => {
+  it('creates fresh default health check headers', () => {
+    const headers = createHealthCheckHeaders();
+
+    assert.deepEqual(headers, DefaultHealthCheckHeaders);
+    assert.notStrictEqual(headers, DefaultHealthCheckHeaders);
+  });
+
+  it('overrides headers case-insensitively', () => {
+    const headers = createHealthCheckHeaders({
+      'Cache-Control': 'public, max-age=30',
+      'Content-Type': 'application/health+json'
+    });
+
+    assert.equal(headers['cache-control'], 'public, max-age=30');
+    assert.equal(headers['content-type'], 'application/health+json');
+    assert.equal(Object.keys(headers).length, 2);
+  });
+});


### PR DESCRIPTION
## Summary

- add route handler integrations for Elysia, Express, and H3/Nitro
- centralize consistent health-check response headers across HTTP integrations
- add framework tests, package entrypoints, peer dependencies, and integration documentation

## Verification

- `pnpm test` (82 tests)
- `pnpm lint`
- `pnpm build`
- `pnpm docs:build`
- `git diff --check`